### PR TITLE
Allow to `addRoute()` routes with dots, e.g. `/README.md`

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,7 +99,8 @@ module.exports = (http) => {
       const queryString = querystring.parse(parsedUrl.query);
       const urlWithoutQueryString = parsedUrl.pathname;
 
-      if (urlWithoutQueryString.includes('.')) { // If the url is for an asset
+      const isOneOfRoutes = routes.includes(urlWithoutQueryString);
+      if (isOneOfRoutes === false && urlWithoutQueryString.includes('.')) { // If the url is for an asset
         let fileType = rawUrl.split('.');
         fileType = fileType[fileType.length - 1];
         let file = rawUrl.replace('/', '');

--- a/tests/index.js
+++ b/tests/index.js
@@ -49,6 +49,11 @@ describe('server', () => {
             res.end(JSON.stringify(queryString));
         });
 
+        router.addRoute('/README.md', (req, res) => {
+            res.writeHead(200, { 'Context-Type': 'text/plain' });
+            res.end('README.md content');
+        });
+
         router.get("/test/get/method", (req, res ) => {
             res.writeHead(200, { 'Content-Type': 'text/html' });
             res.end("test text");
@@ -564,6 +569,19 @@ describe('server', () => {
             ]).then(() => done());
         })
     });
+
+  describe('Routes with a dot in them', () => {
+    it('should be allowed to add routes like `addRoute("/README.md")`', (done) => {
+      http.get(`${SERVER_URL}/README.md`, (res) => {
+        res.statusCode.should.equal(200);
+        let data = '';
+        res.on('data', chunk => data += chunk).on('end', () => {
+          data.should.equal("README.md content");
+          done();
+        });
+      });
+    });
+  });
 
     after(() => {
         router.close();

--- a/tests/index.js
+++ b/tests/index.js
@@ -570,18 +570,18 @@ describe('server', () => {
         })
     });
 
-  describe('Routes with a dot in them', () => {
-    it('should be allowed to add routes like `addRoute("/README.md")`', (done) => {
-      http.get(`${SERVER_URL}/README.md`, (res) => {
-        res.statusCode.should.equal(200);
-        let data = '';
-        res.on('data', chunk => data += chunk).on('end', () => {
-          data.should.equal("README.md content");
-          done();
+    describe('Routes with a dot in them', () => {
+        it('should be allowed to add routes like `addRoute("/README.md")`', (done) => {
+            http.get(`${SERVER_URL}/README.md`, (res) => {
+                res.statusCode.should.equal(200);
+                let data = '';
+                res.on('data', chunk => data += chunk).on('end', () => {
+                  data.should.equal("README.md content");
+                  done();
+                });
+            });
         });
-      });
     });
-  });
 
     after(() => {
         router.close();


### PR DESCRIPTION
I wanted to handle the `/README.md` serving manually, so I did `addRoute("/README.md")` but it didn't work.
This tiny MR makes it work. Until now the code always assumed that routes with a `.` in them are assets. So I extended that logic to look at the routes too, if it is a valid route do NOT see it as an asset, but serve it as a normal route.