### PR TITLE
Ignore multiple slashes (e.g. `http://localhost///`) and still return 200 status code

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,9 +97,8 @@ module.exports = (http) => {
       const urlPathname = parsedUrl.pathname.replaceAll(/\/+/g, '/');
       const urlParts = parsedUrl.pathname.split('/');
       const queryString = querystring.parse(parsedUrl.query);
-      const urlWithoutQueryString = parsedUrl.pathname;
 
-      if (urlWithoutQueryString.includes('.')) { // If the url is for an asset
+      if (urlPathname.includes('.')) { // If the url is for an asset
         let fileType = rawUrl.split('.');
         fileType = fileType[fileType.length - 1];
         let file = rawUrl.replace('/', '');

--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ module.exports = (http) => {
       const routes = Object.keys(this.routes);
       const assetPaths = Object.keys(this.assetPaths);
       const parsedUrl = url.parse(rawUrl);
-      const urlPathname = parsedUrl.pathname;
+      const urlPathname = parsedUrl.pathname.replaceAll(/\/+/g, '/');
       const urlParts = parsedUrl.pathname.split('/');
       const queryString = querystring.parse(parsedUrl.query);
       const urlWithoutQueryString = parsedUrl.pathname;

--- a/tests/index.js
+++ b/tests/index.js
@@ -565,6 +565,21 @@ describe('server', () => {
         })
     });
 
+    describe('Tolerant route handling', () => {
+        it('should ignore multiple slashes (e.g. http://localhost//) and return 200 status code', (done) => {
+            http.get(`${SERVER_URL}//`, (res) => {
+                res.statusCode.should.equal(200);
+                done();
+            });
+        });
+        it('should ignore various multiple slashes (e.g. http://localhost/////another//test) and return 200 status code', (done) => {
+            http.get(`${SERVER_URL}//////another///test`, (res) => {
+                res.statusCode.should.equal(200);
+                done();
+            });
+        });
+    });
+
     after(() => {
         router.close();
     });


### PR DESCRIPTION
This is more a convenience thing, it just sometimes happens that useless slashes are added, just be more tolerant with them.