### PR TITLE
Send the right content-type for js/css files, also depending on their file extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -239,11 +239,11 @@ module.exports = (http) => {
           res.end(`File not found`);
         }
 
-        if (assetType == 'js') {
+        if (assetType === 'js' || file.endsWith('.js')) {
           res.writeHead(200, { 'Content-Type': 'text/javascript' });
         }
 
-        if (assetType == 'css') {
+        if (assetType === 'css' || file.endsWith('.css')) {
           res.writeHead(200, { 'Content-Type': 'text/css' });
         }
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -195,6 +195,21 @@ describe('server', () => {
                 });
             });
         });
+
+        it('should return the content-type `javascript` also when the asset path is some random string', (done) => {
+            router.addAssetPath('random-string1', 'tests/js/');
+            http.get(`${SERVER_URL}/random-string1/empty.js`, (res) => {
+                res.headers['content-type'].should.equal('text/javascript');
+                done();
+            });
+        });
+        it('should return the content-type `css` also when the asset path is some random string', (done) => {
+            router.addAssetPath('random-string2', 'tests/css/');
+            http.get(`${SERVER_URL}/random-string2/style.css`, (res) => {
+                res.headers['content-type'].should.equal('text/css');
+                done();
+            });
+        });
     });
 
     describe('/images/loader.gif', () => {


### PR DESCRIPTION
Until now it was kinda magic dir detection of what content-type was sent, also use the file extension now.
I discovered this, when I wanted to load a <script type=module> where the content-type JS is required, otherwise this wont work.